### PR TITLE
Update value.cr

### DIFF
--- a/src/bson/value.cr
+++ b/src/bson/value.cr
@@ -39,7 +39,7 @@ class BSON
       when LibBSON::Type::BSON_TYPE_DATE_TIME
         spec = LibC::Timespec.new
         spec.tv_sec = v.v_datetime / 1000
-        Time.new(spec, Time::Kind::Utc)
+        Time.new(spec, location: Time::Location::UTC)
       when LibBSON::Type::BSON_TYPE_NULL
         nil
       when LibBSON::Type::BSON_TYPE_REGEX


### PR DESCRIPTION
https://crystal-lang.org/2018/06/15/crystal-0.25.0-released.html

Starting now Time has #location and #offset properties to know the timezone exactly. Time.now and Time.new will return by default information in the local timezone, while Time.utc_now and Time.utc will return information in UTC.